### PR TITLE
Tweaked the "short name" of the map format

### DIFF
--- a/tiled-to-gba-export.js
+++ b/tiled-to-gba-export.js
@@ -164,4 +164,4 @@ var customMapFormat = {
     }
 }
 
-tiled.registerMapFormat("c *.h", customMapFormat)
+tiled.registerMapFormat("gba", customMapFormat)

--- a/tiled-to-gba-export.js
+++ b/tiled-to-gba-export.js
@@ -66,8 +66,7 @@ var customMapFormat = {
         // Only allow valid map sizes to be parsed
         if (!(p_map.width == 32 || p_map.width == 64)
             || !(p_map.height == 32 || p_map.height == 64)) {
-            console.error("Export failed: Invalid map size! Map must be 32x32, 64x32, 32x64 or 64x64 in size.");
-            return;
+            return "Invalid map size! Map must be 32x32, 64x32, 32x64 or 64x64 in size.";
         }
 
         // Standard screenblock size for GBA


### PR DESCRIPTION
The short name is used for disambiguation when the file extension is shared with another format (needed when exporting on the command-line). It is also used to remember which format was used to export a map.