### PR TITLE
Set HFLIP and VFLIP bits for regular backgrounds

### DIFF
--- a/tiled-to-gba-export.js
+++ b/tiled-to-gba-export.js
@@ -48,16 +48,7 @@
 
 /* global FileInfo, TextFile, tiled */
 
-function decimalToHex(p_decimal, p_padding, hflip, vflip) {
-    if (hflip) {
-        // Set the HFLIP bit for this screen entry
-        p_decimal |= (1 << 10);
-    }
-    if (vflip) {
-        // Set the VFLIP bit for this screen entry
-        p_decimal |= (1 << 11);
-    }
-    
+function decimalToHex(p_decimal, p_padding) {
     var hexValue = (p_decimal)
         .toString(16)
         .toUpperCase()
@@ -131,14 +122,22 @@ var customMapFormat = {
                                 let currentTileX = x+(SCREENBLOCKWIDTH*k);
                                 let currentTileY = y+(SCREENBLOCKHEIGHT*j);
                                 let currentTile = currentLayer.cellAt(currentTileX, currentTileY);
-                                let currentTileID = currentTile.tileId;
+                                var currentTileID = currentTile.tileId;
 
                                 // Default to 0x0000 for blank tiles
                                 if (currentTileID == "-1") {
                                     sourceFileData += "0x0000, ";
                                 } else {
-                                    sourceFileData += decimalToHex(currentTileID, 4,
-                                        currentTile.flippedHorizontally, currentTile.flippedVertically)+", ";
+                                    if (currentTile.flippedHorizontally) {
+                                        // Set the HFLIP bit for this screen entry
+                                        currentTileID |= (1 << 10);
+                                    }
+                                    if (currentTile.flippedVertically) {
+                                        // Set the VFLIP bit for this screen entry
+                                        currentTileID |= (1 << 11);
+                                    }
+
+                                    sourceFileData += decimalToHex(currentTileID, 4)+", ";
                                 }
                             }
 

--- a/tiled-to-gba-export.js
+++ b/tiled-to-gba-export.js
@@ -48,7 +48,16 @@
 
 /* global FileInfo, TextFile, tiled */
 
-function decimalToHex(p_decimal, p_padding) {
+function decimalToHex(p_decimal, p_padding, hflip, vflip) {
+    if (hflip) {
+        // Set the HFLIP bit for this screen entry
+        p_decimal |= (1 << 10);
+    }
+    if (vflip) {
+        // Set the VFLIP bit for this screen entry
+        p_decimal |= (1 << 11);
+    }
+    
     var hexValue = (p_decimal)
         .toString(16)
         .toUpperCase()
@@ -121,13 +130,15 @@ var customMapFormat = {
                             for (let x = 0; x < SCREENBLOCKWIDTH; ++x) {
                                 let currentTileX = x+(SCREENBLOCKWIDTH*k);
                                 let currentTileY = y+(SCREENBLOCKHEIGHT*j);
-                                let currentTileID = currentLayer.cellAt(currentTileX, currentTileY).tileId;
+                                let currentTile = currentLayer.cellAt(currentTileX, currentTileY);
+                                let currentTileID = currentTile.tileId;
 
                                 // Default to 0x0000 for blank tiles
                                 if (currentTileID == "-1") {
                                     sourceFileData += "0x0000, ";
                                 } else {
-                                    sourceFileData += decimalToHex(currentTileID, 4)+", ";
+                                    sourceFileData += decimalToHex(currentTileID, 4,
+                                        currentTile.flippedHorizontally, currentTile.flippedVertically)+", ";
                                 }
                             }
 


### PR DESCRIPTION
Following [Tonc's documentation](https://www.coranac.com/tonc/text/regbg.htm#sec-map) for regular tile entries, this sets the correct HFLIP and VFLIP bits of the exported tiles so each tile corresponds to its orientation inside Tiled.

I expect there's an equivalent tweak that can be added for affine tiles, but my GBA knowledge does not extend this far ;)